### PR TITLE
Now with 0.4.x support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "engines":
     {
-        "node": "~0.6.13"
+        "node": ">= 0.4.0"
     },
     "dependencies":
     {

--- a/test/badnets.coffee
+++ b/test/badnets.coffee
@@ -1,6 +1,5 @@
 vows = require 'vows'
 assert = require 'assert'
-util = require 'util'
 Netmask = require('../lib/netmask').Netmask
 
 shouldFailWithError = (msg) ->
@@ -11,13 +10,15 @@ shouldFailWithError = (msg) ->
             catch e
                 return e
         'should fail': (e) ->
-            assert.ok util.isError(e), 'is an Error object'
+            assert.ok isError(e), 'is an Error object'
 
     context["with error `#{msg}'"] = (e) ->
         assert.ok e.message?.toLowerCase().indexOf(msg.toLowerCase()) > -1, "'#{e.message}' =~ #{msg}"
 
     return context
 
+isError = (e) ->
+    return typeof e is 'object' and Object.prototype.toString.call e is '[object Error]'
 
 vows.describe('IPs with bytes greater than 255')
     .addBatch


### PR DESCRIPTION
0.4.x doesn't have util.isError(e), which was being used in one of the tests. Updated tests, to check of an error using the same means as util.isError(), https://github.com/joyent/node/blob/master/lib/util.js#L424. Tests complete with zero errors on 0.4.12.
