### PR TITLE
fixes typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ API
 - `.first`, `.last`: First and last useable address
 - `.contains(ip or block)`: Returns a true if the IP number `ip` is part of the network. That is, a true value is returned if `ip` is between `base` amd `broadcast`. If a Netmask object or a block is given, it returns true only of the given block fits inside the network.
 - `.next(count)`: Without a `count`, return the next block of the same size after the current one. With a count, return the Nth block after the current one. A count of -1 returns the previous block. Undef will be returned if out of legal address space.
+- `.toString()`: The netmask in base/bitmask format (e.g., '216.240.32.0/24')
 
 Installation
 ------------

--- a/lib/netmask.coffee
+++ b/lib/netmask.coffee
@@ -77,6 +77,11 @@ class Netmask
     next: (count=1) ->
         return new Netmask(long2ip(@netLong + (@size * count)), @mask)
 
+    # Returns the complete netmask formatted as `base/bitmask`
+    toString: ->
+        return @base + "/" + @bitmask
+
+
 exports.ip2long = ip2long
 exports.long2ip = long2ip
 exports.Netmask = Netmask

--- a/test/netmasks.coffee
+++ b/test/netmasks.coffee
@@ -29,6 +29,7 @@ for fixture in fixtures
     context["base is `#{base}'"] = (block) -> assert.equal block.base, base
     context["mask is `#{newmask}'"] = (block) -> assert.equal block.mask, newmask
     context["bitmask is `#{bitmask}'"] = (block) -> assert.equal block.bitmask, bitmask
+    context["toString is `#{base}/`#{bitmask}'"] = (block) -> assert.equal block.toString(), block.base + "/" + block.bitmask
     contexts["for #{addr}" + (if mask then " with #{mask}" else '')] = context
 
 vows.describe('Netmaks parsing').addBatch(contexts).export(module)
@@ -49,6 +50,7 @@ vows.describe('Netmask contains IP')
             'contains block 192.168.1.128/25': (block) -> assert.ok block.contains('192.168.1.128/25')
             'does not contain block 192.168.1.0/23': (block) -> assert.ok not block.contains('192.168.1.0/23')
             'does not contain block 192.168.2.0/24': (block) -> assert.ok not block.contains('192.168.2.0/24')
+            'toString equals 192.168.1.0/24': (block) -> assert.equal block.toString(), '192.168.1.0/24'
         'block 192.168.0.0/24':
             topic: -> new Netmask('192.168.0.0/24')
             'does not contain block 192.168': (block) -> assert.ok not block.contains('192.168')


### PR DESCRIPTION
Hi Ryan,

Submitting a simple typo fix for you.  I mistakenly misread your README thinking I could call `.netx()` as a way to read the netmask from an instance.  Five minutes later, I realized this was just a simple typo for `.next()`.

I'm submitting a 2nd pull request with an override of `toString()` to return the netmask as a string.  Figured it would make your life easier to separate out this small fix into an easy pull request.

Cheers,
Steve
