### PR TITLE
package: move "coffee-script" to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,9 @@
     {
         "node": ">= 0.4.0"
     },
-    "dependencies":
-    {
-        "coffee-script": "1.2.0"
-    },
     "devDependencies":
     {
+        "coffee-script": "1.2.0",
         "vows": "*"
     }
 }


### PR DESCRIPTION
So that when users `npm install netmask`, then "coffee-script"
module is not unnecessarily installed along with it.
