### PR TITLE
a patch with mocha test to fix /31 and /32 block.contains

### DIFF
--- a/lib/netmask.coffee
+++ b/lib/netmask.coffee
@@ -72,7 +72,7 @@ class Netmask
             ip = new Netmask(ip)
 
         if ip instanceof Netmask
-            return @contains(ip.base) and @contains(ip.broadcast)
+            return @contains(ip.base) and @contains((ip.broadcast || ip.last))
         else
             return (ip2long(ip) & @maskLong) >>> 0 == ((@netLong & @maskLong)) >>> 0
 

--- a/tests/netmask.js
+++ b/tests/netmask.js
@@ -1,0 +1,24 @@
+/* some troubles with vows
+   here is some mocha test
+
+ npm install  
+ mocha tests/netmask.js
+*/
+var assert = require('assert');
+
+var Netmask = require('../').Netmask;
+
+var block = new Netmask('10.1.2.0/24');
+var b1 = new Netmask('10.1.2.10/29');
+var b2 = new Netmask('10.1.2.10/31');
+var b3 = new Netmask('10.1.2.20/32');
+
+ console.log('first : '+b2.base);
+ console.log('broadcast : '+b2.broadcast);
+ console.log('last : ' + b2.last);
+
+describe("Netmask contains bug", function() {
+  assert.equal(block.contains(b1),true);
+  assert.equal(block.contains(b2),true);
+  assert.equal(block.contains(b3),true);
+});


### PR DESCRIPTION
Thanks for your very useful package.
Here is a issue with patch : 
 
block.contains('192.168.1.1/31') or block.contains('192.168.1.100/32') fail due to undefined broadcast for /31 ot /32

Feel free to remove the mocha test.

Best regards