### PR TITLE
Adding array outputs to the Netmask

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ API
 - `.contains(ip or block)`: Returns a true if the IP number `ip` is part of the network. That is, a true value is returned if `ip` is between `base` and `broadcast`. If a Netmask object or a block is given, it returns true only of the given block fits inside the network.
 - `.forEach(fn)`: Similar to the Array prototype method. It loops through all the useable addresses, ie between `first` and `last`.
 - `.next(count)`: Without a `count`, return the next block of the same size after the current one. With a count, return the Nth block after the current one. A count of -1 returns the previous block. Undef will be returned if out of legal address space.
+- `.toIpArray()`: Returns an array including all the usable addresses.
+- `.toArray()`: Returns an array of all the usable addresses as `Netmask` objects.
 - `.toString()`: The netmask in base/bitmask format (e.g., '216.240.32.0/24')
 
 Installation

--- a/lib/netmask.coffee
+++ b/lib/netmask.coffee
@@ -87,6 +87,23 @@ class Netmask
         range = [ip2long(@first)..ip2long(@last)]
         fn long2ip(long), long, index for long, index in range
 
+    toIpArray: ->
+        iRange = []
+        lRange = [ip2long(@first)..ip2long(@last)]
+        for k,v of lRange
+            iRange.push long2ip(v)
+        return iRange
+
+    toLongArray: ->
+        return [ip2long(@first)..ip2long(@last)]
+
+    toArray: ->
+        iRange = []
+        lRange = [ip2long(@first)..ip2long(@last)]
+        for k,v of lRange
+            iRange.push new Netmask(long2ip(v))
+        return iRange
+
     # Returns the complete netmask formatted as `base/bitmask`
     toString: ->
         return @base + "/" + @bitmask

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "name": "netmask",
     "description": "Parse and lookup IP network blocks",
     "version": "1.0.6",
-    "homepage": "https://github.com/rs/node-netmask",
-    "bugs": "https://github.com/rs/node-netmask/issues",
+    "homepage": "https://github.com/jangins101/node-netmask",
+    "bugs": "https://github.com/jangins101/node-netmask/issues",
     "license": "MIT",
     "repository":
     {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "repository":
     {
         "type": "git",
-        "url": "git://github.com/rs/node-netmask.git"
+        "url": "git://github.com/jangins101/node-netmask.git"
     },
     "keywords": ["net", "mask", "ip", "network", "cidr", "netmask", "subnet", "ipcalc"],
     "main": "./lib/netmask",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
     "author": "Olivier Poitrey <rs@dailymotion.com>",
-    "name": "jnetmask",
+    "name": "netmask",
     "description": "Parse and lookup IP network blocks",
-    "version": "1.0.7",
-    "homepage": "https://github.com/jangins101/node-netmask",
-    "bugs": "https://github.com/jangins101/node-netmask/issues",
+    "version": "1.0.6",
+    "homepage": "https://github.com/rs/node-netmask",
+    "bugs": "https://github.com/rs/node-netmask/issues",
     "license": "MIT",
     "repository":
     {
         "type": "git",
-        "url": "git://github.com/jangins101/node-netmask"
+        "url": "git://github.com/rs/node-netmask.git"
     },
     "keywords": ["net", "mask", "ip", "network", "cidr", "netmask", "subnet", "ipcalc"],
     "main": "./lib/netmask",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
     "author": "Olivier Poitrey <rs@dailymotion.com>",
-    "name": "netmask",
+    "name": "jnetmask",
     "description": "Parse and lookup IP network blocks",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "homepage": "https://github.com/jangins101/node-netmask",
     "bugs": "https://github.com/jangins101/node-netmask/issues",
     "license": "MIT",
     "repository":
     {
         "type": "git",
-        "url": "git://github.com/jangins101/node-netmask.git"
+        "url": "git://github.com/jangins101/node-netmask"
     },
     "keywords": ["net", "mask", "ip", "network", "cidr", "netmask", "subnet", "ipcalc"],
     "main": "./lib/netmask",


### PR DESCRIPTION
the updates in this pull request will add the ability to get an array of `Netmask` objects (using the `toArray()` method)  or an array of IP addresses (using the `toIpArray()` method) given a specific `Netmask` object.