### PR TITLE
Remove dev files to make npm smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 .git*
+tests/
+test/
+example/
+lib/*.coffee


### PR DESCRIPTION
`node_modules` size is important for fast CI. I am thinking of saving resources like it is ecology.