### PR TITLE
Add .slice method to retrieve a list of IPs within a block within a range

### DIFF
--- a/lib/netmask.coffee
+++ b/lib/netmask.coffee
@@ -157,6 +157,11 @@ class Netmask
           long++
         return
 
+    slice: (start, end) ->
+        ips = []
+        @forEach((ip) -> ips.push(ip))
+        return ips.slice(start, end)
+
     # Returns the complete netmask formatted as `base/bitmask`
     toString: ->
         return @base + "/" + @bitmask

--- a/tests/netmask.js
+++ b/tests/netmask.js
@@ -132,4 +132,20 @@ describe('Netmask', () => {
       });
     });
   });
+
+  describe('can return range of IPs from block', () => {
+    let block = new Netmask('10.1.2.0/24');
+
+    it('should be able to return the first N IPs', () => {
+      assert.deepEqual(block.slice(0, 3), ['10.1.2.1', '10.1.2.2', '10.1.2.3']);
+    });
+
+    it('should be able to return the last N IPs', () => {
+      assert.deepEqual(block.slice(block.size - 5, block.size - 1), ['10.1.2.252', '10.1.2.253', '10.1.2.254']);
+    });
+
+    it('should be able to return a range of IPs', () => {
+      assert.deepEqual(block.slice(2, 5), ['10.1.2.3', '10.1.2.4', '10.1.2.5']);
+    });
+  });
 });


### PR DESCRIPTION
Hello!

💁 This PR adds a method to retrieve a subset of IP addresses within a block based on offset. 

The primary reasoning for me putting this together was that in order to do this, I was having to either chain calls to `.next(1)` over and over or use `.forEach` to build a list of the IPs I needed based on offset.

**Alternative Approaches**

- Instead of implementing `.slice`, we could instead provide an accessor that returns an array of all IP addresses within a block. With this, the client can apply whatever transform they want.

**Remaining work**

- [ ] Add tests for "un-happy paths" (what happens when I slice out of range?) 
- [ ] Update documentation

