### PR TITLE
Reject negative CIDR prefixes in IPv4 parsing

### DIFF
--- a/lib/netmask4.ts
+++ b/lib/netmask4.ts
@@ -150,7 +150,7 @@ class Netmask4Impl {
             throw new Error("Invalid net address: " + net);
         }
 
-        if (!(this.bitmask <= 32)) {
+        if (isNaN(this.bitmask) || this.bitmask < 0 || this.bitmask > 32) {
             throw new Error("Invalid mask for ip4: " + maskStr);
         }
 

--- a/tests/badnets.ts
+++ b/tests/badnets.ts
@@ -45,3 +45,8 @@ describe('Ranges that are a power-of-two big, but are not legal blocks', () => {
     shouldFailWithError('218.0.0.0/221.255.255.255', 'Invalid mask');
     shouldFailWithError('218.0.0.4/218.0.0.11', 'Invalid mask');
 });
+
+describe('Negative CIDR prefixes', () => {
+    shouldFailWithError('192.168.1.0/-1', 'Invalid mask');
+    shouldFailWithError('10.0.0.0/-5', 'Invalid mask');
+});


### PR DESCRIPTION
`new Netmask('192.168.1.0/-1')` is accepted silently and matches every address:

```js
const block = new Netmask('192.168.1.0/-1');
block.bitmask                      // -1
block.mask                         // '0.0.0.0'
block.size                         // 8589934592  (2^33)
block.contains('8.8.8.8')          // true
block.contains('255.255.255.255')  // true
```

A negative prefix skips the `if (this.bitmask > 0)` branch, so `maskLong` stays `0`. With a zero mask, `netLong & maskLong` is `0` and `contains()` returns `true` for any input, i.e. the block becomes match-all. The mask check in `lib/netmask4.ts` only guarded the upper bound:

```js
if (!(this.bitmask <= 32)) { ... }   // !(-1 <= 32) === false, so it slips through
```

The IPv6 path already guards the lower bound in `lib/netmask6.ts`:

```js
if (isNaN(prefixLen) || prefixLen < 0 || prefixLen > 128) {
    throw new Error('Invalid mask for IPv6: ' + prefixLen);
}
```

This change mirrors that check on the IPv4 side, so a negative prefix throws `Invalid mask for ip4` instead of producing a match-all block. The legitimate `0.0.0.0/0` case is unaffected, since `bitmask === 0` is still allowed.

I'm flagging this as security-relevant rather than cosmetic: code that uses node-netmask for allow/deny decisions would treat a negative prefix as "matches everything", which can turn a typo or unsanitized input into an access-control bypass. I haven't assigned a severity, just noting the failure mode.

Tests: added `/-1` and `/-5` cases to `tests/badnets.ts` (mirroring the existing IPv6 "throws on negative bitmask" test). Full suite passes (178).
